### PR TITLE
update data_dir permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Cookstyle 7.1.2 fixes
+- Update permissions to 0700 on data_dir
 
 ## 6.1.0 (2020-10-28)
 

--- a/resources/etcd_service_manager_systemd.rb
+++ b/resources/etcd_service_manager_systemd.rb
@@ -19,6 +19,7 @@ action :start do
 
   directory new_resource.data_dir do
     owner new_resource.run_user
+    mode '0700'
     action :create
   end
 


### PR DESCRIPTION
# Description
update data_dir mode to 0700 to fix warning on v3.4.14: https://github.com/etcd-io/etcd/pull/12242
>etcd[709]: check file permission: directory "/hostname.etcd" exist, but the permission is "drwxr-xr-x". The recommended permission is "-rwx------" to prevent possible unprivileged access to the data.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
