### PR TITLE
add configuration flag listen-metrics-urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add configuration flag [listen-metrics-urls](https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/configuration.md#--listen-metrics-urls)
+
 ## 6.2.0 - *2020-12-03*
 
 - Cookstyle 7.1.2 fixes

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ The `etcd_service` resource property list corresponds to the options found in
 
 - `enable_pprof`
 - `metrics`
+- `listen-metrics-urls`
 
 ##### Auth Flpropertiesags
 

--- a/libraries/etcd_common_properties.rb
+++ b/libraries/etcd_common_properties.rb
@@ -80,6 +80,7 @@ module EtcdCookbook
         # Profiling Flags
         property :enable_pprof, [true, false], default: false, desired_state: false
         property :metrics, String, default: 'basic', desired_state: false
+        property :listen_metrics_urls, String, desired_state: false
 
         # Auth Flags
         property :auth_token, String, default: 'simple', desired_state: false

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -58,6 +58,7 @@ module EtcdCookbook
         opts << "-wal-dir=#{new_resource.wal_dir}" unless new_resource.wal_dir.nil?
         opts << "-enable-pprof=#{new_resource.enable_pprof}"
         opts << "-metrics=#{new_resource.metrics}"
+        opts << "-listen-metrics-urls=#{new_resource.listen_metrics_urls}" unless new_resource.listen_metrics_urls.nil?
         opts << "-auth-token=#{new_resource.auth_token}"
         opts
       end


### PR DESCRIPTION
# Description

- Add configuration flag [listen-metrics-urls](https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/configuration.md#--listen-metrics-urls) 
etcd v3.4.14
Certificate is required to access endpoint `/metrics` and `/health` endpoints throught `https`
`--listen-metrics-urls` configuration flag can be used to configure access metrics without authentication

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
