### PR TITLE
Add `-experimental-peer-skip-client-san-verification` flag to chef recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Add configuration flag [-experimental-peer-skip-client-san-verification](https://etcd.io/docs/latest/op-guide/configuration/#--experimental-peer-skip-client-san-verification)
+
 ## 7.0.0 - *2021-05-12*
 
 - Chef 17 compatibility fixes

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ The `etcd_service` resource property list corresponds to the options found in
 - `peer_auto_tls`
 - `etcdctl_client_cert_file`
 - `etcdctl_client_key_file`
+- `experimental_peer_skip_client_san_verification`
 
 ##### Logging properties
 

--- a/libraries/etcd_common_properties.rb
+++ b/libraries/etcd_common_properties.rb
@@ -69,6 +69,7 @@ module EtcdCookbook
         property :peer_auto_tls, [true, false], default: false, desired_state: false
         property :etcdctl_client_cert_file, String, desired_state: false
         property :etcdctl_client_key_file, String, desired_state: false
+        property :experimental_peer_skip_client_san_verification, [true, false], default: false, desired_state: false
 
         # Logging Flags
         property :debug, [true, false], default: false, desired_state: false

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -44,6 +44,7 @@ module EtcdCookbook
         opts << '-peer-client-cert-auth=true' if new_resource.peer_client_cert_auth == true
         opts << "-peer-key-file=#{new_resource.peer_key_file}" unless new_resource.peer_key_file.nil?
         opts << "-peer-trusted-ca-file=#{new_resource.peer_trusted_ca_file}" unless new_resource.peer_trusted_ca_file.nil?
+        opts << '-experimental-peer-skip-client-san-verification=true' if new_resource.experimental_peer_skip_client_san_verification == true
         opts << "-auto-tls=#{new_resource.auto_tls}"
         opts << "-peer-auto-tls=#{new_resource.peer_auto_tls}"
         opts << "-proxy-dial-timeout=#{new_resource.proxy_dial_timeout}" unless new_resource.proxy_dial_timeout.nil?


### PR DESCRIPTION
This flag seems to be present in both 3.4 and 3.5, and is very useful when cluster members have dynamic IP addresses assigned to them.