### PR TITLE
Change Chef requirement in README from 12.15 to 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ## Requirements
 
-- Chef Infra Client 12.15+
+- Chef Infra Client 16+
 - Network accessible web server hosting the etcd binary.
 
 ## Platform Support


### PR DESCRIPTION
# Description

The required Chef version changed long ago, but README was not updated to reflect these changes. 

## Issues Resolved

N/A

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
