### PR TITLE
fix auto compaction retention option in config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This file is used to list changes made in each version of the etcd cookbook.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+Fix usage of `auto_compaction_retention` property in configuration file
+
 ## 9.2.0 - *2025-05-14*
 
 - Add `config_file` property for service resources to enable the passing of configuration options through a [configuration file](https://etcd.io/docs/v3.5/op-guide/configuration/#configuration-file) instead of command-line flags

--- a/templates/default/config/etcd.conf.yml.erb
+++ b/templates/default/config/etcd.conf.yml.erb
@@ -141,7 +141,7 @@ debug: <%= @debug %>
 force-new-cluster: <%= @force_new_cluster %>
 
 auto-compaction-mode: periodic
-auto-compaction-retention: <%= @auto_compaction_retention %>
+auto-compaction-retention: '<%= @auto_compaction_retention %>'
 
 metrics: <%= @metrics %>
 


### PR DESCRIPTION
# Description

etcd does not start if you only provide an integer for `auto_compaction_retention`, yaml :shrug: , we can either provide a string, f.e `30m` `168h` or quote the integer in config file to not break existing service functionality

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
