### PR TITLE
fix: add frozen_string_literal to all resources and libraries

### DIFF
--- a/libraries/_autoload.rb
+++ b/libraries/_autoload.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.push(*Dir[File.expand_path('../files/default/vendor/gems/**/lib', __dir__)])
 $LOAD_PATH.unshift(*Dir[File.expand_path(__dir__)])

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module EtcdCookbook
   module EtcdHelpers
     module Service

--- a/resources/etcd_installation_binary.rb
+++ b/resources/etcd_installation_binary.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 provides :etcd_installation_binary
 provides :etcd_installation
 unified_mode true

--- a/resources/etcd_installation_docker.rb
+++ b/resources/etcd_installation_docker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 provides :etcd_installation_docker
 unified_mode true
 use 'partial/_common'

--- a/resources/etcd_key.rb
+++ b/resources/etcd_key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'etcd'
 
 provides :etcd_key

--- a/resources/etcd_service.rb
+++ b/resources/etcd_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 provides :etcd_service
 unified_mode true
 use 'partial/_common'

--- a/resources/etcd_service_manager_docker.rb
+++ b/resources/etcd_service_manager_docker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 provides :etcd_service_manager_docker
 unified_mode true
 use 'partial/_common'

--- a/resources/etcd_service_manager_systemd.rb
+++ b/resources/etcd_service_manager_systemd.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 provides :etcd_service_manager_systemd
 provides :etcd_service_manager
 unified_mode true

--- a/resources/partial/_common.rb
+++ b/resources/partial/_common.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Set default service name like etcd.service
 
 property :default_service_name,

--- a/test/cookbooks/etcd_test/recipes/auto.rb
+++ b/test/cookbooks/etcd_test/recipes/auto.rb
@@ -1,3 +1,5 @@
+apt_update
+
 etcd_service 'default' do
   action [:create, :start]
 end

--- a/test/cookbooks/etcd_test/recipes/default_service_name.rb
+++ b/test/cookbooks/etcd_test/recipes/default_service_name.rb
@@ -1,3 +1,5 @@
+apt_update
+
 etcd_installation_binary 'default' do
   action :create
 end

--- a/test/cookbooks/etcd_test/recipes/keys.rb
+++ b/test/cookbooks/etcd_test/recipes/keys.rb
@@ -1,3 +1,5 @@
+apt_update
+
 etcd_installation_binary 'default' do
   action :create
   version '3.3.19'

--- a/test/cookbooks/etcd_test/recipes/service_docker.rb
+++ b/test/cookbooks/etcd_test/recipes/service_docker.rb
@@ -1,3 +1,5 @@
+apt_update
+
 # binary installation for kitchen verify
 etcd_installation_binary 'default'
 

--- a/test/cookbooks/etcd_test/recipes/service_docker_multi.rb
+++ b/test/cookbooks/etcd_test/recipes/service_docker_multi.rb
@@ -1,3 +1,5 @@
+apt_update
+
 # binary installation for kitchen verify
 etcd_installation_binary 'default' do
   action :create

--- a/test/cookbooks/etcd_test/recipes/service_systemd.rb
+++ b/test/cookbooks/etcd_test/recipes/service_systemd.rb
@@ -1,3 +1,5 @@
+apt_update
+
 etcd_installation_binary 'default' do
   action :create
 end

--- a/test/cookbooks/etcd_test/recipes/service_systemd_config_file.rb
+++ b/test/cookbooks/etcd_test/recipes/service_systemd_config_file.rb
@@ -1,3 +1,5 @@
+apt_update
+
 etcd_installation_binary 'default' do
   action :create
 end

--- a/test/cookbooks/etcd_test/recipes/service_systemd_multi.rb
+++ b/test/cookbooks/etcd_test/recipes/service_systemd_multi.rb
@@ -1,3 +1,5 @@
+apt_update
+
 etcd_installation_binary 'default' do
   action :create
 end


### PR DESCRIPTION
9 files were missing the `frozen_string_literal: true` pragma.