### PR TITLE
fix(ci): exclude vendor/bundle from cookstyle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
     - files/default/vendor/**/*
+    - vendor/bundle/**/*
 
 Lint/AmbiguousOperator:
   Exclude:


### PR DESCRIPTION
The lint-unit Cookstyle job installs gems with `bundler-cache: true` (into `vendor/bundle/`), then runs `bundle exec cookstyle` against the whole working tree, so it lints vendored gem code (e.g. `unicode-emoji`) instead of just this cookbook. `.rubocop.yml` only excludes `files/default/vendor/**/*` (Chef's own vendored-cookbook-files convention), not bundler's `vendor/bundle`.

This has been failing identically on every push to `main` since at least June 2026 - confirmed via CI history, unrelated to any specific PR's content.

Adds `vendor/bundle/**/*` to the exclude list.